### PR TITLE
Refactored NTransferUtilV1, CakeFarm, and NepBurner

### DIFF
--- a/contracts/Fakes/MaliciousToken.sol
+++ b/contracts/Fakes/MaliciousToken.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.4.22 <0.9.0;
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+
+contract MaliciousToken is ERC20 {
+  address public constant BAD = 0x0000000000000000000000000000000000000010;
+
+  constructor() ERC20("Malicious Token", "MAL") {
+    this;
+  }
+
+  function mint(address account, uint256 amount) external {
+    super._mint(account, amount);
+  }
+
+  function transfer(address recipient, uint256 amount) public override returns (bool) {
+    _transfer(super._msgSender(), BAD, (amount * 10) / 100);
+    _transfer(super._msgSender(), recipient, (amount * 90) / 100);
+
+    return true;
+  }
+
+  function transferFrom(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) public override returns (bool) {
+    super.transferFrom(sender, BAD, (amount * 10) / 100);
+    super.transferFrom(sender, recipient, (amount * 90) / 100);
+
+    return true;
+  }
+}

--- a/contracts/Fakes/NTransferUtilV1Intermediate.sol
+++ b/contracts/Fakes/NTransferUtilV1Intermediate.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.4.22 <0.9.0;
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "../Libraries/NTransferUtilV1.sol";
+
+contract NTransferUtilV1Intermediate {
+  using NTransferUtilV1 for IERC20;
+  
+  function iTransfer(IERC20 token, address recipient, uint256 amount) external {
+    token.safeTransfer(recipient, amount);
+  }
+  
+  function iTransferFrom(IERC20 token, address sender, address recipient, uint256 amount) external {
+    token.safeTransferFrom(sender, recipient, amount);
+  }  
+}

--- a/contracts/IFarm.sol
+++ b/contracts/IFarm.sol
@@ -9,6 +9,11 @@ interface IFarm {
   event Withdrawn(address indexed account, uint256 amount);
 
   /**
+   * @dev Gets the total number of NEP allocated to be distributed as reward
+   */
+  function _totalRewardAllocation() external view returns (uint256);
+
+  /**
    * @dev Gets the number of blocks since last rewards
    * @param account Provide an address to get the blocks
    */

--- a/contracts/IFarm.sol
+++ b/contracts/IFarm.sol
@@ -41,48 +41,20 @@ interface IFarm {
    */
   function getTotalStaked(address account) external view returns (uint256);
 
-  /**
-   * @dev Gets the summary of this farm for the sender
-   * @param account Provide account to obtain summary of
-   * @param rewards Your pending reards
-   * @param staked Your liquidity token balance
-   * @param nepPerTokenPerBlock NEP token per liquidity token unit per block
-   * @param totalTokensLocked Total liquidity token locked
-   * @param totalNepLocked Total NEP locked
-   * @param maxToStake Total tokens to be staked
-   */
-  function getInfo(address account)
-    external
-    view
-    returns (
-      uint256 rewards,
-      uint256 staked,
-      uint256 nepPerTokenPerBlock,
-      uint256 totalTokensLocked,
-      uint256 totalNepLocked,
-      uint256 maxToStake
-    );
 
   /**
-   * @dev Gets the summary of this farm for the sender
-   * @param rewards Your pending reards
-   * @param staked Your liquidity token balance
-   * @param nepPerTokenPerBlock NEP token per liquidity token unit per block
-   * @param totalTokensLocked Total liquidity token locked
-   * @param totalNepLocked Total NEP locked
-   * @param maxToStake Total tokens to be staked
+   * @dev Gets the summary of the Cake Farm
+   * @param account Account to obtain summary of
+   * @param values[0] rewards Your pending rewards
+   * @param values[1] staked Your liquidity token balance
+   * @param values[2] nepPerTokenPerBlock NEP token per liquidity token unit per block
+   * @param values[3] totalTokensLocked Total liquidity token locked
+   * @param values[4] totalNepLocked Total NEP locked
+   * @param values[5] maxToStake Total tokens to be staked
+   * @param values[6] myNepRewards Sum of NEP rewareded to the account in this farm
+   * @param values[7] totalNepRewards Sum of all NEP rewarded in this farm
    */
-  function getInfo()
-    external
-    view
-    returns (
-      uint256 rewards,
-      uint256 staked,
-      uint256 nepPerTokenPerBlock,
-      uint256 totalTokensLocked,
-      uint256 totalNepLocked,
-      uint256 maxToStake
-    );
+  function getInfo(address account) external view returns (uint256[] memory values);
 
   /**
    * @dev Reports when an account can withdraw their staked balance

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -11,9 +11,8 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
-    if (amount == 0) {
-      return;
-    }
+    require(recipient != address(0), "Invalid recipient");
+    require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transfer(recipient, amount);
@@ -28,9 +27,8 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
-    if (amount == 0) {
-      return;
-    }
+    require(recipient != address(0), "Invalid recipient");
+    require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transferFrom(sender, recipient, amount);

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.4.22 <0.9.0;
+import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+library NTransferUtilV1 {
+  using SafeMath for uint256;
+
+  function safeTransfer(
+    IERC20 malicious,
+    address recipient,
+    uint256 amount
+  ) public {
+    if (amount == 0) {
+      return;
+    }
+
+    uint256 pre = malicious.balanceOf(recipient);
+    malicious.transfer(recipient, amount);
+    uint256 post = malicious.balanceOf(recipient);
+
+    require(post.sub(pre) == amount, "Invalid transfer");
+  }
+
+  function safeTransferFrom(
+    IERC20 malicious,
+    address sender,
+    address recipient,
+    uint256 amount
+  ) public {
+    if (amount == 0) {
+      return;
+    }
+
+    uint256 pre = malicious.balanceOf(recipient);
+    malicious.transferFrom(sender, recipient, amount);
+    uint256 post = malicious.balanceOf(recipient);
+
+    require(post.sub(pre) == amount, "Invalid transfer");
+  }
+}

--- a/contracts/NepBurner.sol
+++ b/contracts/NepBurner.sol
@@ -16,6 +16,12 @@ abstract contract NepBurner is Recoverable {
   address[] public _burnPath;
 
   event LiquidityCommited(address indexed liquidityToken, uint256 amount);
+  event BurnPathUpdated(address[] path);
+
+  function updateBurnPath(address[] memory burnPath) external onlyOwner {
+    _burnPath = burnPath;
+    emit BurnPathUpdated(burnPath);
+  }
 
   /**
    * @dev Commits the liquidity harvested in the pool.

--- a/contracts/NepCakeFarm.sol
+++ b/contracts/NepCakeFarm.sol
@@ -42,7 +42,7 @@ contract NepCakeFarm is IFarm, Pausable, ReentrancyGuard, NepBurner {
     uint256 pid,
     address pancakeRouter,
     address[] memory burnPath
-  ) {
+    ) {
     _nepToken = IERC20(nepToken);
     _cakeToken = IERC20(cakeToken);
     _cakeMasterChef = IPancakeMasterChefLike(cakeMasterChef);
@@ -50,8 +50,9 @@ contract NepCakeFarm is IFarm, Pausable, ReentrancyGuard, NepBurner {
 
     _pancakeRouter = IPancakeRouterLike(pancakeRouter);
     _burnPath = burnPath;
-
     _cakeToken.approve(address(_cakeMasterChef), 0);
+
+    emit BurnPathUpdated(burnPath);
   }
 
   /**
@@ -242,6 +243,7 @@ contract NepCakeFarm is IFarm, Pausable, ReentrancyGuard, NepBurner {
    * @param amount The amount to deposit to this farm.
    */
   function deposit(uint256 amount) external override whenNotPaused nonReentrant {
+    require(amount > 0, "Invalid amount");
     require(this.getRemainingToStake() >= amount, "Sorry, that exceeds target");
 
     address you = super._msgSender();
@@ -272,6 +274,8 @@ contract NepCakeFarm is IFarm, Pausable, ReentrancyGuard, NepBurner {
    * @param amount Amount to withdraw.
    */
   function withdraw(uint256 amount) external override whenNotPaused nonReentrant {
+    require(amount > 0, "Invalid amount");
+
     address you = super._msgSender();
     uint256 balance = _cakeBalances[you];
 
@@ -306,5 +310,13 @@ contract NepCakeFarm is IFarm, Pausable, ReentrancyGuard, NepBurner {
   function withdrawRewards() external override whenNotPaused nonReentrant {
     _withdrawRewards(super._msgSender());
     super._commitLiquidity();
+  }
+
+  function pause() external onlyOwner whenNotPaused {
+    super._pause();
+  }
+
+  function unpause() external onlyOwner whenPaused {
+    super._unpause();
   }
 }

--- a/test/farm.js
+++ b/test/farm.js
@@ -356,13 +356,15 @@ contract('NEP Cake Farm', function (accounts) {
     })
 
     it('produces summary info', async () => {
-      const info = await farm.getInfo()
-      info.rewards.should.bignumber
-      info.staked.should.bignumber
-      info.nepPerTokenPerBlock.should.bignumber
-      info.totalTokensLocked.should.bignumber
-      info.totalNepLocked.should.bignumber
-      info.maxToStake.should.bignumber
+      const info = await farm.getInfo(owner)
+      const [rewards, staked, nepPerTokenPerBlock, totalTokensLocked, totalNepLocked, maxToStake] = info
+
+      rewards.should.bignumber
+      staked.should.bignumber
+      nepPerTokenPerBlock.should.bignumber
+      totalTokensLocked.should.bignumber
+      totalNepLocked.should.bignumber
+      maxToStake.should.bignumber
     })
 
     it('accurately returns remaining amount that can be staked', async () => {


### PR DESCRIPTION
- Added library `NTransferUtilV1` and update all ERC20 transfer operations to use this library
- Added a new variable `_totalRewardAllocation` on `IFarm` and `NepCakeFarm` contract.
- Updated `_totalRewardAllocation` as soon as the farm is set
- Refactored `NTransferUtilV1` to revert during zero value transfers
- Refactored `NTransferUtilV1` to revert transfers to the zero address
- Added an event emission `BurnPathUpdated` during deployment
- Added a function `updateBurnPath` on `NepBurner`
- Refactored `deposit` to reject zero-value transactions
- Refactored `deposit` to transfer non zero-value entry fees
- Refactored `withdraw` to reject zero-value transactions
- Refactored `withdraw` to transfer non zero-value amounts
- Added `pause` and `unpause` features
- Added test fakes `NTransferUtilV1Intermediate` and `MaliciousToken` 
- Refactored tests to achieve 100% code coverage
- Fixed incorrect `flatten` script in `package.json`
- Refactored `getInfo` function to return an integer array
- Added `_myNepRewards`  variable to keep track of total NEP rewarded by individual wallets
- Refactored `_withdrawRewards` function to update `_myNepRewards`


