### PR TITLE
Refactors

### DIFF
--- a/contracts/IFarm.sol
+++ b/contracts/IFarm.sol
@@ -14,6 +14,11 @@ interface IFarm {
   function _totalRewardAllocation() external view returns (uint256);
 
   /**
+   * @dev Gets the remaining number of NEP tokens in this farm to be distributed as reward
+   */
+  function _remainingNEPRewards() external view returns (uint256);
+
+  /**
    * @dev Gets the number of blocks since last rewards
    * @param account Provide an address to get the blocks
    */
@@ -53,6 +58,7 @@ interface IFarm {
    * @param values[5] maxToStake Total tokens to be staked
    * @param values[6] myNepRewards Sum of NEP rewareded to the account in this farm
    * @param values[7] totalNepRewards Sum of all NEP rewarded in this farm
+   * @param values[8] remainingNEPRewards Remaining NEP in this farm
    */
   function getInfo(address account) external view returns (uint256[] memory values);
 

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -2,22 +2,25 @@
 pragma solidity >=0.4.22 <0.9.0;
 import "openzeppelin-solidity/contracts/utils/math/SafeMath.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/utils/SafeERC20.sol";
 
 library NTransferUtilV1 {
   using SafeMath for uint256;
+  using SafeERC20 for IERC20;
 
   function safeTransfer(
     IERC20 malicious,
     address recipient,
     uint256 amount
-  ) public {
+  ) external {
     require(recipient != address(0), "Invalid recipient");
     require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
-    malicious.transfer(recipient, amount);
+    malicious.safeTransfer(recipient, amount);
     uint256 post = malicious.balanceOf(recipient);
 
+    // slither-disable-next-line incorrect-equality
     require(post.sub(pre) == amount, "Invalid transfer");
   }
 
@@ -26,14 +29,15 @@ library NTransferUtilV1 {
     address sender,
     address recipient,
     uint256 amount
-  ) public {
+  ) external {
     require(recipient != address(0), "Invalid recipient");
     require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
-    malicious.transferFrom(sender, recipient, amount);
+    malicious.safeTransferFrom(sender, recipient, amount);
     uint256 post = malicious.balanceOf(recipient);
 
+    // slither-disable-next-line incorrect-equality
     require(post.sub(pre) == amount, "Invalid transfer");
   }
 }

--- a/contracts/NepBurner.sol
+++ b/contracts/NepBurner.sol
@@ -33,14 +33,16 @@ abstract contract NepBurner is Recoverable {
     _cakeMasterChef.leaveStaking(0);
     uint256 amount = _cakeToken.balanceOf(address(this));
 
+    // slither-disable-next-line incorrect-equality
     if (amount == 0) {
       return;
     }
 
-    _cakeToken.approve(address(_pancakeRouter), amount);
+    require(_cakeToken.approve(address(_pancakeRouter), amount), "Pancake Router approval failed");
 
-    // solhint-disable-next-line not-rely-on-time
+    // slither-disable-next-line unused-return
     _pancakeRouter.swapExactTokensForTokens(amount, 0, _burnPath, 0x0000000000000000000000000000000000000001, block.timestamp.add(1 hours));
+    // solhint-disable-previous-line not-rely-on-time
     emit LiquidityCommited(address(_cakeToken), amount);
   }
 }

--- a/contracts/Recoverable.sol
+++ b/contracts/Recoverable.sol
@@ -9,6 +9,8 @@ abstract contract Recoverable is Ownable {
    */
   function recoverEther() external onlyOwner {
     address owner = super.owner();
+
+    // slither-disable-next-line arbitrary-send
     payable(owner).transfer(address(this).balance);
   }
 
@@ -21,6 +23,6 @@ abstract contract Recoverable is Ownable {
     IERC20 bep20 = IERC20(token);
 
     uint256 balance = bep20.balanceOf(address(this));
-    bep20.transfer(owner, balance);
+    require(bep20.transfer(owner, balance), "Transfer failed");
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "test": "truffle test",
-    "flatten": "truffle-flattener ./contracts/NepCakeFarm.sol > ./contracts/.NepCakeFarm.flat.sol",
-    "coverage": "truffle run coverage"
+    "flatten": "flatsol ./contracts/NepCakeFarm.sol > ./.flatsol/NepCakeFarm.sol",
+    "coverage": "truffle run coverage",
+    "slither": "slither ."
   },
   "repository": {
     "type": "git",

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,10 @@
+{
+  "exclude_informational": true,
+  "exclude_low": true,
+  "exclude_medium": false,
+  "exclude_high": false,
+  "truffle_ignore_compile": false,
+  "disable_color": false,
+  "legacy_ast": false,
+  "filter_paths": "Fakes|Migrations.sol|openzeppelin"
+}


### PR DESCRIPTION
- Added `_remainingNEPRewards` variable to keep track of remaining NEP reward amount in the farm
- Refactored `getInfo` to return `rewardAllocation` and `remainingNEPRewards`
- Refactored `_commitLiquidity`, `_reduceCakeMasterChefAllownace`, and `_approveCakeMasterChef` to throw if the ERC-20 approve operation does not return true
- Updated `_minStakingPeriodInBlocks` to 24 hours
- Moved constructor logic to `initialize` function to allow updating farm variables in the future
- Refactored `getTotalBlocksSinceLastReward` to fix slither warning
- Updated `recoverToken` to throw if the ERC-20 transfer operation does not return true
- Updated `NTransferUtilV1` library to use Open Zeppelin safe ERC-20 operations
- Updated `NTransferUtilV1` functions to be external